### PR TITLE
add truthy_cached_property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.egg-info/
+tube.py
 
 build/
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## DEV
+* Add `@truthy_cached_property`
+
 ## 1.0.3
 * Converted README from markdown to reStructuredText so it works on PyPi.
 

--- a/README.rst
+++ b/README.rst
@@ -34,12 +34,18 @@ Usage
     from property_caching import (cached_property,
                                   class_cached_property,
                                   clear_property_cache,
-                                  set_property_cache)
+                                  set_property_cache,
+                                  truthy_cached_property)
 
     class Dummy:
         @cached_property
         def foo(self):
             return self.service.expensive_operation()
+
+        @truthy_cached_property
+        def bar(self):
+            # this value will only be cached if it doesn't evaluate to false:
+            return self.service.expensive_operation2()
 
         @class_cached_property
         def service(self):

--- a/property_caching/__init__.py
+++ b/property_caching/__init__.py
@@ -20,7 +20,7 @@ def cached_property(fn):
 def truthy_cached_property(fn):
     def _truthy_cached_property(self):
         return _get_property_value(
-            fn, self, _OBJ_CACHE_ATTR_NAME, only_cache_true_vals=True)
+            fn, self, _OBJ_CACHE_ATTR_NAME, cache_false_results=False)
     return property(update_wrapper(_truthy_cached_property, fn))
 
 
@@ -45,14 +45,14 @@ def _get_cache(obj, cache_attr_name=_OBJ_CACHE_ATTR_NAME):
     return getattr(obj, cache_attr_name, {})
 
 
-def _get_property_value(fn, obj, cache_attr_name, only_cache_true_vals=False):
+def _get_property_value(fn, obj, cache_attr_name, cache_false_results=True):
     result = None
     cache = _get_cache(obj, cache_attr_name)
     if fn.__name__ not in cache:
         result = fn(obj)
         # re-read cache since it might be already populated by nested functions
         cache = _get_cache(obj, cache_attr_name)
-        if result or not only_cache_true_vals:
+        if result or cache_false_results:
             cache[fn.__name__] = result
         setattr(obj, cache_attr_name, cache)
     return cache.get(fn.__name__, result)

--- a/property_caching/__init__.py
+++ b/property_caching/__init__.py
@@ -56,7 +56,7 @@ def _get_property_value(fn, obj, cache_attr_name, cache_false_results=True):
     cache_key = fn.__name__
 
     if cache_key in cache:
-        return cache[fn.__name__]
+        return cache[cache_key]
 
     result = fn(obj)
     if result or cache_false_results:

--- a/property_caching/__init__.py
+++ b/property_caching/__init__.py
@@ -40,7 +40,7 @@ def _get_cache(obj, cache_attr_name=_OBJ_CACHE_ATTR_NAME):
 
 def _get_property_value(fn, obj, cache_attr_name):
     cache = _get_cache(obj, cache_attr_name)
-    if not fn.__name__ in cache:
+    if fn.__name__ not in cache:
         result = fn(obj)
         # re-read cache since it might be already populated by nested functions
         cache = _get_cache(obj, cache_attr_name)

--- a/property_caching/__init__.py
+++ b/property_caching/__init__.py
@@ -17,6 +17,13 @@ def cached_property(fn):
     return property(update_wrapper(_cached_property, fn))
 
 
+def truthy_cached_property(fn):
+    def _truthy_cached_property(self):
+        return _get_property_value(
+            fn, self, _OBJ_CACHE_ATTR_NAME, only_cache_true_vals=True)
+    return property(update_wrapper(_truthy_cached_property, fn))
+
+
 def set_property_cache(obj, name, value):
     cache = _get_cache(obj)
     cache[name] = value
@@ -38,12 +45,14 @@ def _get_cache(obj, cache_attr_name=_OBJ_CACHE_ATTR_NAME):
     return getattr(obj, cache_attr_name, {})
 
 
-def _get_property_value(fn, obj, cache_attr_name):
+def _get_property_value(fn, obj, cache_attr_name, only_cache_true_vals=False):
+    result = None
     cache = _get_cache(obj, cache_attr_name)
     if fn.__name__ not in cache:
         result = fn(obj)
         # re-read cache since it might be already populated by nested functions
         cache = _get_cache(obj, cache_attr_name)
-        cache[fn.__name__] = result
+        if result or not only_cache_true_vals:
+            cache[fn.__name__] = result
         setattr(obj, cache_attr_name, cache)
-    return cache[fn.__name__]
+    return cache.get(fn.__name__, result)

--- a/tests/test_property_caching.py
+++ b/tests/test_property_caching.py
@@ -1,5 +1,7 @@
 import unittest
-from property_caching import *
+from property_caching import (
+    cached_property, class_cached_property, clear_property_cache,
+    is_property_cached, set_property_cache, truthy_cached_property)
 
 
 class TestClass(object):

--- a/tests/test_property_caching.py
+++ b/tests/test_property_caching.py
@@ -10,6 +10,7 @@ class TestClass(object):
     def __init__(self):
         self.counter = 0
         self.counter2 = 0
+        self.attribute = None
 
     @cached_property
     def method(self):
@@ -29,6 +30,14 @@ class TestClass(object):
     @cached_property
     def method4(self):
         return self.method2
+
+    @cached_property
+    def cached_attribute(self):
+        return self.attribute
+
+    @truthy_cached_property
+    def truthy_cached_attribute(self):
+        return self.attribute
 
 
 class BaseTestCase(unittest.TestCase):
@@ -54,6 +63,16 @@ class CachedPropertyTestCase(BaseTestCase):
         self.assertEqual(self.test_obj.method2, 1)
         self.assertEqual(self.test_obj.counter2, 1)
 
+    def test_caches_falsey_values(self):
+        for falsey_value in (False, None, '', 0, [], {}):
+            test_obj = TestClass()
+
+            test_obj.attribute = falsey_value
+            self.assertEqual(test_obj.cached_attribute, falsey_value)
+
+            test_obj.attribute = 99
+            self.assertEqual(test_obj.cached_attribute, falsey_value)
+
 
 class ClassCachedPropertyTestCase(BaseTestCase):
     """A method decorated with @class_cached_property"""
@@ -69,6 +88,23 @@ class ClassCachedPropertyTestCase(BaseTestCase):
         obj2 = TestClass()
         self.assertEqual(obj2.method3, 1)
         self.assertEqual(TestClass.counter3, 1)
+
+
+class TruthyCachedPropertyTestCase(BaseTestCase):
+    """A method decorated with @truthy_cached_property"""
+
+    def test_only_caches_truthy_values(self):
+        for falsey_value in (False, None, '', 0, [], {}):
+            test_obj = TestClass()
+
+            test_obj.attribute = falsey_value
+            self.assertEqual(test_obj.truthy_cached_attribute, falsey_value)
+
+            test_obj.attribute = 99
+            self.assertEqual(test_obj.truthy_cached_attribute, 99)
+
+            test_obj.attribute = 123
+            self.assertEqual(test_obj.truthy_cached_attribute, 99)
 
 
 class ClearPropertyCacheTestCase(BaseTestCase):


### PR DESCRIPTION
This adds a `@truthy_cached_property` decorator that only caches truthy values.

The name isn't ideal, but I couldn't come up with anything more revealing that wasn't cumbersome. I figure the README can explain it, and it meshes well with `class_cached_property`.

Replaces my initial attempt at this in #13.